### PR TITLE
Potential fix for code scanning alert no. 76: Code injection

### DIFF
--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -28,12 +28,16 @@ global.sleep = (time: number) => {
 export function showProductReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     // Truncate id to avoid unintentional RCE
-    const id = !utils.isChallengeEnabled(challenges.noSqlCommandChallenge) ? Number(req.params.id) : utils.trunc(req.params.id, 40)
+    const challengeEnabled = utils.isChallengeEnabled(challenges.noSqlCommandChallenge)
+    // Use a secure query if the challenge is not enabled, otherwise allow the challenge code for CTF/educational purposes only
+    const id = challengeEnabled ? utils.trunc(req.params.id, 40) : Number(req.params.id)
 
     // Measure how long the query takes, to check if there was a nosql dos attack
-    const t0 = new Date().getTime()
+    const query = challengeEnabled
+      ? { $where: 'this.product == ' + id }
+      : { product: id }
 
-    db.reviewsCollection.find({ $where: 'this.product == ' + id }).then((reviews: Review[]) => {
+    db.reviewsCollection.find(query).then((reviews: Review[]) => {
       const t1 = new Date().getTime()
       challengeUtils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
       const user = security.authenticatedUsers.from(req)


### PR DESCRIPTION
Potential fix for [https://github.com/walterlobatojr-svg/juice-shop-ada/security/code-scanning/76](https://github.com/walterlobatojr-svg/juice-shop-ada/security/code-scanning/76)

**General Fix Approach:**  
Avoid ever injecting user input directly into a JavaScript context that is executed, especially via `$where`, unless strict sanitization/validation is performed. The best approach is to avoid using `$where` for queries involving user-supplied data. Instead, use parameterized or direct property queries using MongoDB's standard query syntax, which is immune to code injection.

**Specifics for this code:**  
- For the non-challenge scenario (where `isChallengeEnabled` returns false), `id` is already coerced to a number, so we can safely query `product: id`.
- For the challenge scenario, where the insecure code path is currently enabled to support the challenge, it would be best to:
  - Only use `$where` when the challenge is enabled and you intentionally want the vulnerable code present.
  - For all other cases, avoid using `$where` and use a standard property query (`{ product: id }`), ensuring that `id` is either a number or, at minimum, alphanumeric.
  - If the challenge must still be enabled for gamification/educational exploitation, wrap the insecure path in the appropriate condition, and in the secure/default path, enforce a strict type check and use direct field matching.

**File/regions to change:**  
Edit only `routes/showProductReviews.ts`, inside the handler of `showProductReviews`. Update the query on line 36 to use a safe MongoDB query (`{ product: id }`) when `noSqlCommandChallenge` is not enabled, and strictly coerce/validate `id` as a number or string as appropriate.

**Methods/imports needed:**  
No new methods or imports are strictly needed, but you may want to enforce stricter validation or use utilities for that if available in the shown portion.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
